### PR TITLE
Add TserverLoggingTest and make configuration changes

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/QueryParameters.java
+++ b/warehouse/query-core/src/main/java/datawave/query/QueryParameters.java
@@ -1,5 +1,7 @@
 package datawave.query;
 
+import datawave.query.iterator.QueryLogIterator;
+
 public class QueryParameters {
 
     /**
@@ -221,4 +223,9 @@ public class QueryParameters {
      * Used to specify model or DB fields that must be treated as strict (cannot be skipped if normalization fails)
      */
     public static final String STRICT_FIELDS = "strict.fields";
+
+    /**
+     * Controls whether a query's ID is logged on the tserver using {@link QueryLogIterator}
+     */
+    public static final String TSERVER_LOGGING_ACTIVE = "tserver.logging.active";
 }

--- a/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
+++ b/warehouse/query-core/src/main/java/datawave/query/config/ShardQueryConfiguration.java
@@ -2756,12 +2756,15 @@ public class ShardQueryConfiguration extends GenericQueryConfiguration implement
 
     @Override
     public boolean equals(Object o) {
-        if (this == o)
+        if (this == o) {
             return true;
-        if (o == null || getClass() != o.getClass())
+        }
+        if (o == null || getClass() != o.getClass()) {
             return false;
-        if (!super.equals(o))
+        }
+        if (!super.equals(o)) {
             return false;
+        }
         // @formatter:off
         ShardQueryConfiguration that = (ShardQueryConfiguration) o;
         return isTldQuery() == that.isTldQuery() &&

--- a/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
+++ b/warehouse/query-core/src/main/java/datawave/query/iterator/QueryOptions.java
@@ -59,6 +59,7 @@ import datawave.data.type.Type;
 import datawave.ingest.data.config.ingest.CompositeIngest;
 import datawave.query.Constants;
 import datawave.query.DocumentSerialization;
+import datawave.query.QueryParameters;
 import datawave.query.attributes.Document;
 import datawave.query.attributes.ExcerptFields;
 import datawave.query.attributes.UniqueFields;
@@ -277,11 +278,6 @@ public class QueryOptions implements OptionDescriber {
     public static final String FIELD_COUNTS = "field.counts";
     public static final String TERM_COUNTS = "term.counts";
 
-    /**
-     * Controls whether a query's ID is logged on the tserver using {@link QueryLogIterator}
-     */
-    public static final String TSERVER_LOGGING_ACTIVE = "tserver.logging.active";
-
     protected Map<String,String> options;
 
     protected String scanId;
@@ -448,9 +444,6 @@ public class QueryOptions implements OptionDescriber {
     private CountMap fieldCounts;
     private CountMap termCounts;
     private CountMapSerDe mapSerDe;
-
-    // Controls whether query IDs are logged on the tserver level via QueryLogIterator.
-    private boolean tserverLoggingActive = false;
 
     public void deepCopy(QueryOptions other) {
         this.options = other.options;
@@ -1289,7 +1282,6 @@ public class QueryOptions implements OptionDescriber {
         options.put(TERM_FREQUENCY_AGGREGATION_THRESHOLD_MS, "TermFrequency aggregations that exceed this threshold are logged as a warning");
         options.put(FIELD_COUNTS, "Map of field counts from the global index");
         options.put(TERM_COUNTS, "Map of term counts from the global index");
-        options.put(TSERVER_LOGGING_ACTIVE, "Whether the queryID will be logged during queries");
         return new IteratorOptions(getClass().getSimpleName(), "Runs a query against the DATAWAVE tables", options, null);
     }
 
@@ -1786,10 +1778,6 @@ public class QueryOptions implements OptionDescriber {
             }
         }
 
-        if (options.containsKey(TSERVER_LOGGING_ACTIVE)) {
-            this.tserverLoggingActive = Boolean.parseBoolean(options.get(TSERVER_LOGGING_ACTIVE));
-        }
-
         return true;
     }
 
@@ -2273,14 +2261,6 @@ public class QueryOptions implements OptionDescriber {
 
     public void setTfAggregationThresholdMs(int tfAggregationThresholdMs) {
         this.tfAggregationThresholdMs = tfAggregationThresholdMs;
-    }
-
-    public boolean isTserverLoggingActive() {
-        return this.tserverLoggingActive;
-    }
-
-    public void setTserverLoggingActive(boolean tserverLoggingActive) {
-        this.tserverLoggingActive = tserverLoggingActive;
     }
 
     /**

--- a/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/ShardQueryLogic.java
@@ -1159,6 +1159,11 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implements
             setCollectTimingDetails(false);
         }
 
+        // Configure whether query IDs are logged on the tservers.
+        String tserverLoggingActive = settings.findParameter(QueryParameters.TSERVER_LOGGING_ACTIVE).getParameterValue().trim();
+        if (!tserverLoggingActive.isEmpty()) {
+            config.setTserverLoggingActive(Boolean.parseBoolean(tserverLoggingActive));
+        }
         stopwatch.stop();
     }
 
@@ -2920,5 +2925,13 @@ public class ShardQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implements
 
     public void setRebuildDatatypeFilterPerShard(boolean rebuildDatatypeFilterPerShard) {
         getConfig().setRebuildDatatypeFilterPerShard(rebuildDatatypeFilterPerShard);
+    }
+
+    public boolean isTserverLoggingActive() {
+        return getConfig().isTserverLoggingActive();
+    }
+
+    public void setTserverLoggingActive(boolean tserverLoggingActive) {
+        getConfig().setTserverLoggingActive(tserverLoggingActive);
     }
 }

--- a/warehouse/query-core/src/test/java/datawave/query/TserverLoggingTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/TserverLoggingTest.java
@@ -1,0 +1,180 @@
+package datawave.query;
+
+import static datawave.query.testframework.CitiesDataType.CityEntry;
+import static datawave.query.testframework.CitiesDataType.CityField;
+import static datawave.query.testframework.CitiesDataType.getManager;
+import static datawave.query.testframework.CitiesDataType.getTestAuths;
+import static datawave.query.testframework.RawDataManager.EQ_OP;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.UUID;
+
+import org.apache.accumulo.core.client.IteratorSetting;
+import org.apache.accumulo.core.security.Authorizations;
+import org.apache.log4j.Logger;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import datawave.core.query.configuration.QueryData;
+import datawave.microservice.query.QueryImpl;
+import datawave.query.iterator.QueryLogIterator;
+import datawave.query.testframework.AbstractFunctionalQuery;
+import datawave.query.testframework.AccumuloSetup;
+import datawave.query.testframework.CitiesDataType;
+import datawave.query.testframework.FieldConfig;
+import datawave.query.testframework.FileType;
+import datawave.query.testframework.GenericCityFields;
+
+public class TserverLoggingTest extends AbstractFunctionalQuery {
+
+    @ClassRule
+    public static AccumuloSetup accumuloSetup = new AccumuloSetup();
+    private static final Logger log = Logger.getLogger(TserverLoggingTest.class);
+
+    private final Set<Authorizations> authSet = Collections.singleton(getTestAuths());
+
+    @BeforeClass
+    public static void filterSetup() throws Exception {
+        FieldConfig generic = new GenericCityFields();
+        Set<String> comp = new HashSet<>();
+        comp.add(CityField.CITY.name());
+        comp.add(CityField.COUNTRY.name());
+        generic.addCompositeField(comp);
+        generic.addIndexField(CityField.COUNTRY.name());
+        generic.addIndexOnlyField(CityField.STATE.name());
+
+        accumuloSetup.setData(FileType.CSV, new CitiesDataType(CityEntry.generic, generic));
+        client = accumuloSetup.loadTables(log);
+    }
+
+    public TserverLoggingTest() {
+        super(getManager());
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        this.logic = null;
+    }
+
+    /**
+     * Verify that when tserver logging active is set to false via the config, that the {@link QueryLogIterator} is not added to the iterator stack.
+     */
+    @Test
+    public void testTserverLoggingActiveFalseConfig() throws Exception {
+        logic.getConfig().setTserverLoggingActive(false);
+
+        initializeQuery(Collections.emptyMap());
+
+        assertQueryLogIteratorPresence(false);
+    }
+
+    /**
+     * Verify that when tserver logging active is set to true via the config, that the {@link QueryLogIterator} is added to the iterator stack.
+     */
+    @Test
+    public void testTserverLoggingActiveTrueConfig() throws Exception {
+        logic.getConfig().setTserverLoggingActive(true);
+
+        initializeQuery(Collections.emptyMap());
+
+        assertQueryLogIteratorPresence(true);
+    }
+
+    /**
+     * Verify that when tserver logging active is set to false via the query parameters, that the {@link QueryLogIterator} is not added to the iterator stack.
+     */
+    @Test
+    public void testTserverLoggingActiveFalseOption() throws Exception {
+        Map<String,String> options = new HashMap<>();
+        options.put(QueryParameters.TSERVER_LOGGING_ACTIVE, "false");
+
+        initializeQuery(options);
+
+        assertQueryLogIteratorPresence(false);
+    }
+
+    /**
+     * Verify that when tserver logging active is set to true via the query parameters, that the {@link QueryLogIterator} is added to the iterator stack.
+     */
+    @Test
+    public void testTserverLoggingActiveTrueOption() throws Exception {
+        Map<String,String> options = new HashMap<>();
+        options.put(QueryParameters.TSERVER_LOGGING_ACTIVE, "true");
+
+        initializeQuery(options);
+
+        assertQueryLogIteratorPresence(true);
+    }
+
+    /**
+     * Verify that when tserver logging active is set to false via the config, but overridden by the query parameters with a value of true, that the
+     * {@link QueryLogIterator} is added to the iterator stack.
+     */
+    @Test
+    public void testQueryParameterOverridesConfigForValueOfTrue() throws Exception {
+        logic.getConfig().setTserverLoggingActive(false);
+        Map<String,String> options = new HashMap<>();
+        options.put(QueryParameters.TSERVER_LOGGING_ACTIVE, "true");
+
+        initializeQuery(options);
+
+        assertQueryLogIteratorPresence(true);
+    }
+
+    /**
+     * Verify that when tserver logging active is set to false via the config, but overridden by the query parameters with a value of true, that the
+     * {@link QueryLogIterator} is not added to the iterator stack.
+     */
+    @Test
+    public void testQueryParameterOverridesConfigForValueOfFalse() throws Exception {
+        logic.getConfig().setTserverLoggingActive(true);
+        Map<String,String> options = new HashMap<>();
+        options.put(QueryParameters.TSERVER_LOGGING_ACTIVE, "false");
+
+        initializeQuery(options);
+
+        assertQueryLogIteratorPresence(false);
+    }
+
+    private void initializeQuery(Map<String,String> options) throws Exception {
+        String query = CityField.STATE.name() + EQ_OP + "'ohio'";
+
+        QueryImpl q = new QueryImpl();
+        q.setBeginDate(this.dataManager.getShardStartEndDate()[0]);
+        q.setEndDate(this.dataManager.getShardStartEndDate()[1]);
+        q.setQuery(query);
+        q.setParameters(options);
+
+        q.setId(UUID.randomUUID());
+        q.setPagesize(Integer.MAX_VALUE);
+        q.setQueryAuthorizations(auths.toString());
+        this.logic.initialize(client, q, authSet);
+    }
+
+    private void assertQueryLogIteratorPresence(boolean presenceRequired) {
+        // Fetch the query data.
+        Iterator<QueryData> iterator = this.logic.getConfig().getQueriesIter();
+        while (iterator.hasNext()) {
+            QueryData queryData = iterator.next();
+            Assert.assertEquals(presenceRequired, isQueryLogIteratorPresent(queryData));
+        }
+    }
+
+    private boolean isQueryLogIteratorPresent(QueryData data) {
+        return data.getSettings().stream().map(IteratorSetting::getIteratorClass).anyMatch(c -> c.equals(QueryLogIterator.class.getName()));
+    }
+
+    @Override
+    protected void testInit() {
+        this.auths = getTestAuths();
+        this.documentKey = CityField.EVENT_ID.name();
+    }
+}

--- a/warehouse/query-core/src/test/java/datawave/query/tables/ShardQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/tables/ShardQueryLogicTest.java
@@ -360,4 +360,9 @@ public abstract class ShardQueryLogicTest {
 
         runTestQuery(expected, queryString, format.parse("20091231"), format.parse("20150101"), extraParameters);
     }
+
+    @Test
+    public void testTserverLoggingActive() {
+
+    }
 }


### PR DESCRIPTION
Add TserverLogging test to verify that queryLogIterator is created and added to the iterator stack when desired. Additionally, move tserver.logging.active property to QueryParameters, and ensure that if specified, the query parameter will override the configuration settings. Additionally, make it possible to set the tserver active logging flag from a ShardQueryLogic configuration setting in the QueryLogicFactory.xml file.