### PR TITLE
[CI] 2936-document-scheduler-block-cache

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentIdProducer.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentIdProducer.java
@@ -111,8 +111,8 @@ public class DocumentIdProducer implements RunnableWithContext {
         scanner.addScanIterator(createIteratorSetting());
 
         if (config.getSearchScanHintTable() != null && config.getSearchScanHintPool() != null) {
-            Preconditions.checkArgument(context.getTableName().equals(config.getRetrievalScanHintTable()), "Table name did not match execution hint");
-            scanner.setExecutionHints(Map.of("scan_type", config.getSearchScanHintPool()));
+            Preconditions.checkArgument(context.getTableName().equals(config.getSearchScanHintTable()), "Table name did not match execution hint");
+            scanner.setExecutionHints(DocumentScanHints.searchHints(config));
         }
 
         if (config.getSearchConsistencyLevel() != null) {

--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentRangeScan.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentRangeScan.java
@@ -157,7 +157,7 @@ public class DocumentRangeScan implements RunnableWithContext {
 
         if (config.getRetrievalScanHintTable() != null && config.getRetrievalScanHintPool() != null) {
             Preconditions.checkArgument(tableName.equals(config.getRetrievalScanHintTable()), "Table name did not match execution hint");
-            scanner.setExecutionHints(Map.of("scan_type", config.getRetrievalScanHintPool()));
+            scanner.setExecutionHints(DocumentScanHints.retrievalHints(config));
         }
 
         if (config.getSearchConsistencyLevel() != null) {

--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentScanHints.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentScanHints.java
@@ -1,0 +1,52 @@
+package datawave.next.scanner;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Builds the execution hints for the search and retrieval scans issued by the document scheduler.
+ * <p>
+ * Each scan carries a {@code scan_type} hint that selects the server-side executor, plus an optional block cache policy.
+ * <p>
+ * The policy uses the {@code cacheUsage.<scanType>.index} and {@code cacheUsage.<scanType>.data} keys from the SimpleScanDispatcher documentation.
+ */
+final class DocumentScanHints {
+
+    static final String SCAN_TYPE = "scan_type";
+
+    private DocumentScanHints() {
+        // utility class
+    }
+
+    /**
+     * Build the execution hints for a search (field index / candidate) scan.
+     */
+    static Map<String,String> searchHints(DocumentScannerConfig config) {
+        Map<String,String> hints = new HashMap<>();
+        hints.put(SCAN_TYPE, config.getSearchScanHintPool());
+        addCacheUsage(hints, config.getSearchScanHintPool(), config.getSearchIndexCacheUsage(), config.getSearchDataCacheUsage());
+        return hints;
+    }
+
+    /**
+     * Build the execution hints for a retrieval (document / event) scan.
+     */
+    static Map<String,String> retrievalHints(DocumentScannerConfig config) {
+        Map<String,String> hints = new HashMap<>();
+        hints.put(SCAN_TYPE, config.getRetrievalScanHintPool());
+        addCacheUsage(hints, config.getRetrievalScanHintPool(), config.getRetrievalIndexCacheUsage(), config.getRetrievalDataCacheUsage());
+        return hints;
+    }
+
+    /**
+     * Add the cacheUsage hints for the given scan type when a policy is configured; a null policy is skipped so the table default applies.
+     */
+    private static void addCacheUsage(Map<String,String> hints, String scanType, String indexCacheUsage, String dataCacheUsage) {
+        if (indexCacheUsage != null) {
+            hints.put("cacheUsage." + scanType + ".index", indexCacheUsage);
+        }
+        if (dataCacheUsage != null) {
+            hints.put("cacheUsage." + scanType + ".data", dataCacheUsage);
+        }
+    }
+}

--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentScannerConfig.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentScannerConfig.java
@@ -82,6 +82,13 @@ public class DocumentScannerConfig implements Serializable {
     private String retrievalScanHintTable;
     private String retrievalScanHintPool;
 
+    // per-scan block cache policy applied via execution hints; null leaves a hint unset so the table default applies (see SimpleScanDispatcher)
+    private String searchIndexCacheUsage;
+    private String searchDataCacheUsage;
+
+    private String retrievalIndexCacheUsage;
+    private String retrievalDataCacheUsage;
+
     // IMMEDIATE or EVENTUAL
     private String searchConsistencyLevel;
     private String retrievalConsistencyLevel;
@@ -242,6 +249,10 @@ public class DocumentScannerConfig implements Serializable {
                     .append(searchScanHintPool, other.searchScanHintPool)
                     .append(retrievalScanHintTable, other.retrievalScanHintTable)
                     .append(retrievalScanHintPool, other.retrievalScanHintPool)
+                    .append(searchIndexCacheUsage, other.searchIndexCacheUsage)
+                    .append(searchDataCacheUsage, other.searchDataCacheUsage)
+                    .append(retrievalIndexCacheUsage, other.retrievalIndexCacheUsage)
+                    .append(retrievalDataCacheUsage, other.retrievalDataCacheUsage)
                     .append(searchConsistencyLevel, other.searchConsistencyLevel)
                     .append(retrievalConsistencyLevel, other.retrievalConsistencyLevel)
                     .isEquals();
@@ -266,6 +277,10 @@ public class DocumentScannerConfig implements Serializable {
                 .append(searchScanHintPool)
                 .append(retrievalScanHintTable)
                 .append(retrievalScanHintPool)
+                .append(searchIndexCacheUsage)
+                .append(searchDataCacheUsage)
+                .append(retrievalIndexCacheUsage)
+                .append(retrievalDataCacheUsage)
                 .append(searchConsistencyLevel)
                 .append(retrievalConsistencyLevel)
                 .hashCode();
@@ -390,6 +405,38 @@ public class DocumentScannerConfig implements Serializable {
 
     public void setRetrievalScanHintPool(String retrievalScanHintPool) {
         this.retrievalScanHintPool = retrievalScanHintPool;
+    }
+
+    public String getSearchIndexCacheUsage() {
+        return searchIndexCacheUsage;
+    }
+
+    public void setSearchIndexCacheUsage(String searchIndexCacheUsage) {
+        this.searchIndexCacheUsage = searchIndexCacheUsage;
+    }
+
+    public String getSearchDataCacheUsage() {
+        return searchDataCacheUsage;
+    }
+
+    public void setSearchDataCacheUsage(String searchDataCacheUsage) {
+        this.searchDataCacheUsage = searchDataCacheUsage;
+    }
+
+    public String getRetrievalIndexCacheUsage() {
+        return retrievalIndexCacheUsage;
+    }
+
+    public void setRetrievalIndexCacheUsage(String retrievalIndexCacheUsage) {
+        this.retrievalIndexCacheUsage = retrievalIndexCacheUsage;
+    }
+
+    public String getRetrievalDataCacheUsage() {
+        return retrievalDataCacheUsage;
+    }
+
+    public void setRetrievalDataCacheUsage(String retrievalDataCacheUsage) {
+        this.retrievalDataCacheUsage = retrievalDataCacheUsage;
     }
 
     public String getSearchConsistencyLevel() {

--- a/warehouse/query-core/src/test/java/datawave/next/scanner/DocumentScanHintsTest.java
+++ b/warehouse/query-core/src/test/java/datawave/next/scanner/DocumentScanHintsTest.java
@@ -1,0 +1,82 @@
+package datawave.next.scanner;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class DocumentScanHintsTest {
+
+    @Test
+    public void searchHintsAlwaysIncludeScanType() {
+        DocumentScannerConfig config = new DocumentScannerConfig();
+        config.setSearchScanHintPool("search");
+
+        Map<String,String> hints = DocumentScanHints.searchHints(config);
+
+        // with no cache policy configured, only the scan_type hint is set
+        assertEquals(1, hints.size());
+        assertEquals("search", hints.get("scan_type"));
+    }
+
+    @Test
+    public void searchHintsIncludeConfiguredCacheUsage() {
+        DocumentScannerConfig config = new DocumentScannerConfig();
+        config.setSearchScanHintPool("search");
+        config.setSearchIndexCacheUsage("enabled");
+        config.setSearchDataCacheUsage("enabled");
+
+        Map<String,String> hints = DocumentScanHints.searchHints(config);
+
+        assertEquals(3, hints.size());
+        assertEquals("search", hints.get("scan_type"));
+        // the cache usage hint key embeds the scan type, per the SimpleScanDispatcher documentation
+        assertEquals("enabled", hints.get("cacheUsage.search.index"));
+        assertEquals("enabled", hints.get("cacheUsage.search.data"));
+    }
+
+    @Test
+    public void searchHintsOmitUnsetCachePolicies() {
+        DocumentScannerConfig config = new DocumentScannerConfig();
+        config.setSearchScanHintPool("search");
+        config.setSearchIndexCacheUsage("opportunistic");
+        // data cache usage intentionally left unset
+
+        Map<String,String> hints = DocumentScanHints.searchHints(config);
+
+        assertEquals(2, hints.size());
+        assertEquals("opportunistic", hints.get("cacheUsage.search.index"));
+        assertFalse(hints.containsKey("cacheUsage.search.data"));
+    }
+
+    @Test
+    public void retrievalHintsIncludeConfiguredCacheUsage() {
+        DocumentScannerConfig config = new DocumentScannerConfig();
+        config.setRetrievalScanHintPool("retrieval");
+        config.setRetrievalIndexCacheUsage("disabled");
+        config.setRetrievalDataCacheUsage("disabled");
+
+        Map<String,String> hints = DocumentScanHints.retrievalHints(config);
+
+        assertEquals(3, hints.size());
+        assertEquals("retrieval", hints.get("scan_type"));
+        assertEquals("disabled", hints.get("cacheUsage.retrieval.index"));
+        assertEquals("disabled", hints.get("cacheUsage.retrieval.data"));
+    }
+
+    @Test
+    public void cacheUsageKeyTracksScanTypeName() {
+        DocumentScannerConfig config = new DocumentScannerConfig();
+        config.setRetrievalScanHintPool("pool-a");
+        config.setRetrievalDataCacheUsage("disabled");
+
+        Map<String,String> hints = DocumentScanHints.retrievalHints(config);
+
+        assertEquals("disabled", hints.get("cacheUsage.pool-a.data"));
+        // the default scan type name is not used when a custom pool is configured
+        assertNull(hints.get("cacheUsage.retrieval.data"));
+    }
+}


### PR DESCRIPTION
Iteration PR to run datawave CI on the fork. **Not for merge.**

## Upstream
[Issue #2936 — Configure Block Cache Policy for Document Scheduler](https://github.com/NationalSecurityAgency/datawave/issues/2936?ref=fork-ci)

The document scheduler's search and retrieval scans have opposite cache behavior. This adds a cacheUsage setting for each and sends it as an execution hint with the scan_type, so they can be tuned separately. Unset values are left off so the table default applies.

Also fixes a copy-paste bug where the search scan checked its table name against the retrieval hint table.
