### PR TITLE
[CI] 1913-unfielded-edge-query-error

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/query/tables/edge/EdgeQueryLogic.java
+++ b/warehouse/query-core/src/main/java/datawave/query/tables/edge/EdgeQueryLogic.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.accumulo.core.client.AccumuloClient;
 import org.apache.accumulo.core.client.BatchScanner;
@@ -391,11 +392,24 @@ public class EdgeQueryLogic extends BaseQueryLogic<Entry<Key,Value>> implements 
 
         script = TreeFlatteningRebuildingVisitor.flatten(script);
 
+        verifyQueryIsFielded(script);
+
         EdgeTableRangeBuildingVisitor visitor = new EdgeTableRangeBuildingVisitor(getConfig().includeStats(), getConfig().getDataTypes(),
                         getConfig().getMaxQueryTerms(), getConfig().getRegexDataTypes(), getEdgeFields());
         visitationContext = (VisitationContext) script.jjtAccept(visitor, null);
 
         return visitationContext.getRanges();
+    }
+
+    /**
+     * Reject unfielded edge query terms (bare values that the parsers map to ANY_FIELD) early with a clear message instead of a confusing downstream failure.
+     */
+    private void verifyQueryIsFielded(ASTJexlScript script) {
+        AtomicBoolean hasUnfieldedTerm = new AtomicBoolean(false);
+        script.jjtAccept(new JexlASTHelper.HasUnfieldedTermVisitor(), hasUnfieldedTerm);
+        if (hasUnfieldedTerm.get()) {
+            throw new IllegalArgumentException("Edge queries do not support unfielded terms; every term must specify a field (e.g. SOURCE == 'value').");
+        }
     }
 
     /**

--- a/warehouse/query-core/src/test/java/datawave/query/edge/ExtendedEdgeQueryLogicTest.java
+++ b/warehouse/query-core/src/test/java/datawave/query/edge/ExtendedEdgeQueryLogicTest.java
@@ -85,6 +85,21 @@ public class ExtendedEdgeQueryLogicTest extends EdgeQueryFunctionalTest {
         compareResults(logic, factory, expected);
     }
 
+    @Test
+    public void testUnfieldedQueryThrowsClearError() throws Exception {
+        // a bare, unfielded LUCENE term is mapped to _ANYFIELD_ and is not supported by edge queries
+        QueryImpl q = configQuery("JUPITER", auths);
+        q.addParameter("query.syntax", "LUCENE");
+        try {
+            runLogic(q, auths);
+            Assert.fail("expected an IllegalArgumentException for an unfielded edge query");
+        } catch (IllegalArgumentException e) {
+            String message = e.getMessage();
+            Assert.assertNotNull(message);
+            Assert.assertTrue("error should mention unfielded terms, but was: " + message, message.contains("unfielded terms"));
+        }
+    }
+
     @Test(expected = UnsupportedOperationException.class)
     public void testUnknownFunction() throws Exception {
 


### PR DESCRIPTION
Iteration PR to run datawave CI on the fork. **Not for merge.**

## Upstream
[Issue #1913 — Gracefully throw an error with unfielded edge queries](https://github.com/NationalSecurityAgency/datawave/issues/1913?ref=fork-ci)

## Problem
Edge queries require every term to be fielded, but an unfielded term — a bare value, which the query parsers map to the `_ANYFIELD_` identifier — slipped through to range building and failed with a confusing error, leaving users unsure what was wrong.

## Solution
Detect unfielded terms while configuring ranges, reusing the already-parsed AST and the existing (previously unused) `JexlASTHelper.HasUnfieldedTermVisitor`, and reject them up front with a clear `IllegalArgumentException`. No duplicate parsing and no fragile hand-walking of the tree — unlike the 2023 WIP attempt (#1916), which predates the JEXL3 migration and would no longer compile. Adds a test that submits a bare unfielded LUCENE term and asserts the clear error message.