### PR TITLE
[CI] 2916-document-scheduler-cleanup

### DIFF
--- a/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentRangeScan.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/DocumentRangeScan.java
@@ -160,7 +160,7 @@ public class DocumentRangeScan implements RunnableWithContext {
             scanner.setExecutionHints(Map.of("scan_type", config.getRetrievalScanHintPool()));
         }
 
-        if (config.getSearchConsistencyLevel() != null) {
+        if (config.getRetrievalConsistencyLevel() != null) {
             scanner.setConsistencyLevel(ConsistencyLevel.valueOf(config.getRetrievalConsistencyLevel()));
         }
         return scanner;

--- a/warehouse/query-core/src/main/java/datawave/next/scanner/QueryDataConsumer.java
+++ b/warehouse/query-core/src/main/java/datawave/next/scanner/QueryDataConsumer.java
@@ -61,24 +61,19 @@ public class QueryDataConsumer implements Runnable {
             }
             while (iterator.hasNext()) {
                 QueryData queryData = iterator.next();
-                if (log.isDebugEnabled()) {
-                    log.debug("got query data: {}", queryData.getRanges().iterator().next().getStartKey().toStringNoTime());
-                }
                 if (queryData == null) {
                     stats.incrementNullDataSeen();
                     log.info("query data was null");
                     continue;
                 }
-                if (queryData.getSettings() == null) {
-                    log.info("query data settings was null");
-                }
-                if (queryData.getRanges() == null) {
-                    log.info("query data ranges was null");
-                }
                 stats.incrementQueryDataSeen();
 
-                Preconditions.checkArgument(queryData.getSettings().size() == 1);
-                Preconditions.checkArgument(queryData.getRanges().size() == 1);
+                Preconditions.checkArgument(queryData.getSettings() != null && queryData.getSettings().size() == 1, "expected exactly one settings entry");
+                Preconditions.checkArgument(queryData.getRanges() != null && queryData.getRanges().size() == 1, "expected exactly one range");
+
+                if (log.isDebugEnabled()) {
+                    log.debug("got query data: {}", queryData.getRanges().iterator().next().getStartKey().toStringNoTime());
+                }
 
                 Range range = queryData.getRanges().iterator().next();
                 if (isDocumentRange(range)) {


### PR DESCRIPTION
Iteration PR to run datawave CI on the fork. **Not for merge.**

## Upstream
[Issue #2916 — Iterator cleanup in document scheduler](https://github.com/NationalSecurityAgency/datawave/issues/2916?ref=fork-ci)

## Problem
The document scheduler accrued tech debt; the issue lists several cleanup items. Two are concrete correctness bugs:
- `DocumentRangeScan.createScanner()` (the retrieval path) checked the **search** consistency level but applied the **retrieval** one — so a configured retrieval level could be silently ignored, and a `ConsistencyLevel.valueOf(null)` NPE was possible when only one of the two levels was set.
- `QueryDataConsumer.run()` dereferenced the query data in a debug log **before** its null check, and logged null settings/ranges only to fall through into a guaranteed NPE.

## Solution
Fix the two bugs: check **and** apply the retrieval consistency level (matching the search-path logic in `DocumentIdProducer`); skip null query data first, fold null-guards into the size preconditions with clear messages, and move the debug log after validation.

Scoped deliberately. The issue's broader items (extracting common code to core classes, reworking iterator miss/next control flow) are larger design changes better done as their own focused PRs, and the "only add query-iterator options in the query-iterator path" item is already satisfied in the current code. Keeping this PR to the concrete, low-risk correctness fixes.