### PR TITLE
[CI CONTROL - DO NOT MERGE] Unmodified accumulo4-2026 baseline

### DIFF
--- a/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/TableConfigurationUtil.java
+++ b/warehouse/ingest-core/src/main/java/datawave/ingest/mapreduce/job/TableConfigurationUtil.java
@@ -782,3 +782,5 @@ public class TableConfigurationUtil {
         this.tableConfigCache.update();
     }
 }
+
+// CI baseline probe - no functional change


### PR DESCRIPTION
**Control experiment — do not merge.**

This is unmodified upstream `accumulo4-2026` (`c8b04d0`) plus a single comment line, so CI has something to diff. It contains none of our quickstart changes.

Purpose: PR #15 fails with `Could not find artifact org.apache.accumulo:accumulo-server-base:jar:4.0.0-SNAPSHOT` in `datawave-in-memory-accumulo` — a module and dependency our changes never touch. This run establishes whether that failure is a pre-existing property of the branch or something we introduced.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DvPe9CKPRq4gZCogoJVe1Y)_